### PR TITLE
Don't throw errors when switched off

### DIFF
--- a/lib/readdir.js
+++ b/lib/readdir.js
@@ -104,7 +104,7 @@
       var deferred = Q.defer();
 
       fs.readdir(dir, function (err, contents) {
-         if (err) deferred.reject(err);
+         if (err) deferred_error(deferred, err, options);
          else if (!contents.length) {
             deferred.resolve();
          }
@@ -116,7 +116,7 @@
                fs.stat(newPath, function (err, stat) {
                   var isDirectory = stat && stat.isDirectory();
 
-                  if (err) deferred.reject(err);
+                  if (err) deferred_error(deferred, err, options);
                   else if (isDirectory) {
                      if(exports.INCLUDE_DIRECTORIES & options) {
                         appendTo.push(newPath.substring(prefixLength) + '/');
@@ -139,6 +139,15 @@
       });
 
       return deferred.promise;
+   }
+
+   function deferred_error(deferred, error, options) {
+      if (exports.IGNORE_ERRORS & options) {
+         deferred.resolve();
+      }
+      else {
+         deferred.reject(error);
+      }
    }
 
    /**
@@ -206,7 +215,12 @@
     */
    exports.readSync = function(basePath, includeFilters, options) {
       var rootDir = basePath.replace(/\/$/, '') + '/';
-      return apply_filters(basePath, read_dir_sync(rootDir, [], rootDir.length, options), includeFilters, options);
+      if (!fs.existsSync(rootDir)) {
+         return [];
+      }
+      else {
+         return apply_filters(basePath, read_dir_sync(rootDir, [], rootDir.length, options), includeFilters, options);
+      }
    };
 
    /**
@@ -290,5 +304,12 @@
     * @type {Number}
     */
    exports.NON_RECURSIVE = 32;
+
+   /**
+    * Bitwise option for preventing errors reading directories from aborting the scan whenever possible - includes
+    * incorrectly rooted relative symlinks and missing root directory.
+    * @type {number}
+    */
+   exports.IGNORE_ERRORS = 64;
 
 }(typeof module == 'undefined' ? (window.ReadDir = {}) : module.exports));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "readdir",
   "description": "Reads a directory and return results with the ability to use Ant style file match patterns ",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Steve King <steve@mydev.co>",
   "contributors": [
     {

--- a/test/test.js
+++ b/test/test.js
@@ -167,3 +167,26 @@ var readdir = require('../lib/readdir');
    });
 
 }());
+
+(function() {
+   var readdir = require('../lib/readdir.js'),
+       read = readdir.read;
+
+   read('./example_dir/missing', readdir.IGNORE_ERRORS, function (error, everyFile) {
+      process.nextTick(function () {
+         Assert.equal(error, null, 'Should not have thrown an error while scanning non-existent directory');
+         Assert.deepEqual(everyFile, [], 'No files given that the directory does not exist');
+      });
+   });
+
+}());
+
+(function() {
+   var readdir = require('../lib/readdir.js'),
+       read = readdir.readSync;
+
+   Assert.deepEqual(
+       read('./example_dir/missing', null, readdir.IGNORE_ERRORS), [],
+       'No files given that the directory does not exist');
+
+}());


### PR DESCRIPTION
Don't throw errors when either switched off in async mode or when the root directory doesn't exist in sync mode
